### PR TITLE
FIx prepend

### DIFF
--- a/build/parts/append-prepend.js
+++ b/build/parts/append-prepend.js
@@ -6,6 +6,6 @@ $.prototype.append = function(a) {
 
 $.prototype.prepend = function(a) {
   return this.each(function(b) {
-    b.insertBefore(a[0], b.parentNode.firstChild);
+    b.insertBefore(a[0], b.firstChild);
   });
 };


### PR DESCRIPTION
Prepend was inserting the node as a child of it's parent instead of as it's own first child.